### PR TITLE
Fix eager loading of group students

### DIFF
--- a/app/services/education.py
+++ b/app/services/education.py
@@ -51,7 +51,17 @@ class CRUDGroup(CRUDBase[Group, GroupCreate, GroupUpdate]):
         """
         Получить группу со студентами
         """
-        return db.query(Group).options(joinedload(Group.students)).filter(Group.id == id).first()
+        group = (
+            db.query(Group)
+            .options(joinedload(Group.students).joinedload(StudentGroup.student))
+            .filter(Group.id == id)
+            .first()
+        )
+
+        if group:
+            group.__dict__["students"] = [sg.student for sg in group.students]
+
+        return group
     
     def get_with_all(self, db: Session, *, id: int) -> Optional[Group]:
         """


### PR DESCRIPTION
## Summary
- eagerly load StudentGroup.student when fetching groups
- return groups with student instances instead of StudentGroup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a23f5afc832d9b90b01e01dd06c0