### PR TITLE
Refactor group details retrieval

### DIFF
--- a/app/api/v1/endpoints/groups.py
+++ b/app/api/v1/endpoints/groups.py
@@ -80,14 +80,14 @@ def read_group(
     Получить информацию о группе по ID
     """
     # Получаем группу с детальной информацией
-    group_details = group_service.get_with_details(db, id=group_id)
-    if not group_details:
+    group = group_service.get_with_details(db, id=group_id)
+    if not group:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Группа не найдена",
         )
-    
-    return group_details
+
+    return group
 
 
 @router.put("/{group_id}", response_model=GroupInDB)

--- a/app/services/education.py
+++ b/app/services/education.py
@@ -86,28 +86,27 @@ class CRUDGroup(CRUDBase[Group, GroupCreate, GroupUpdate]):
         """
         return db.query(Group).filter(Group.is_active == True).offset(skip).limit(limit).all()
     
-    def get_with_details(self, db: Session, *, id: int) -> Optional[Dict[str, Any]]:
+    def get_with_details(self, db: Session, *, id: int) -> Optional[Group]:
         """
-        Получить группу с детальной информацией
+        Получить группу с детальной информацией и подсчетом количества студентов
         """
         group = self.get_with_all(db, id=id)
         if not group:
             return None
-        
-        # Подсчет количества студентов
+
+        # Подсчет количества активных студентов в группе
         students_count = (
             db.query(func.count(StudentGroup.student_id))
             .filter(
                 StudentGroup.group_id == id,
-                StudentGroup.is_active == True
+                StudentGroup.is_active == True,
             )
             .scalar()
         )
-        
-        return {
-            "group": group,
-            "students_count": students_count
-        }
+
+        # Дополняем объект группы атрибутом students_count
+        setattr(group, "students_count", students_count)
+        return group
     
     def add_student(
         self, db: Session, *, group_id: int, student_id: int, is_active: bool = True


### PR DESCRIPTION
## Summary
- simplify CRUDGroup.get_with_details to return a Group instance with `students_count`
- adjust group read endpoint to return the augmented group directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a2425d20832da9bdb4be54333f43